### PR TITLE
Using message embeds instead of content for error/information messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dvs-tech-moderation-bot",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dvs-tech-moderation-bot",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@discordjs/rest": "^1.0.1",

--- a/src/config.json
+++ b/src/config.json
@@ -2,6 +2,5 @@
   "token": "",
   "appID": "",
   "guildID": "",
-  "mongoUser": "",
-  "mongoPass": ""
+  "mongoUri": ""
 }

--- a/src/data/db.js
+++ b/src/data/db.js
@@ -1,6 +1,6 @@
 const MongoClient = require("mongodb").MongoClient;
 const config = require("../config.json");
-const uri = `mongodb+srv://${config.mongoUser}:${config.mongoPass}@cluster0.awzkqo3.mongodb.net/?retryWrites=true&w=majority`;
+const uri = config.mongoUri;
 var client = new MongoClient(uri, { useNewUrlParser: true, useUnifiedTopology: true });
 const collection = client.db("elite").collection("warnings");
 

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,3 +1,4 @@
+const embed = require('../interactions/embeds')
 module.exports = {
   name: "interactionCreate",
   async execute(interaction, client) {
@@ -9,11 +10,8 @@ module.exports = {
       try {
         await command.execute(interaction);
       } catch (error) {
-        client.Logger.error(`Error executing command ${command.data.name} : \n ${error}`);
-        await interaction.reply({
-          content: "There was an error while executing this command!",
-          ephemeral: true,
-        });
+        client.Logger.error(`Error executing command ${command.data.name} : \n ${error}`);        
+        await embed.errorSoft(interaction, "There was an error while executing this command!")
       }
     } else if (interaction.isButton()) {
       const button = client.buttons.get(interaction.customId);
@@ -26,11 +24,7 @@ module.exports = {
         interaction.client.Logger.error(
           `Error executing button ${button.data.customId} : \n ${error}`
         );
-
-        await interaction.reply({
-          content: "There was an error while executing this button!",
-          ephemeral: true,
-        });
+        await embed.errorSoft(interaction, "There was an error while executing this button!");
       }
     } else if (interaction.isSelectMenu()) {
       const selectMenu = client.selectMenus.get(interaction.customId);
@@ -43,10 +37,7 @@ module.exports = {
         interaction.client.Logger.error(
           `Error executing selectMenu ${selectMenu.data.customId} : \n ${error}`
         );
-        await interaction.reply({
-          content: "There was an error while executing this select menu!",
-          ephemeral: true,
-        });
+        await embed.errorSoft(interaction, "There was an error while executing this select menu!");
       }
     }
   },

--- a/src/interactions/commands/ban.js
+++ b/src/interactions/commands/ban.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder, PermissionsBitField, CommandInteraction } = require("discord.js");
+const { errorSoft } = require("../embeds");
 
 module.exports = {
   helpinfo: "This comand is used to ban a user from the server",
@@ -23,29 +24,26 @@ module.exports = {
 
     // makes sure the user is in the guild
     if (!member) {
-      return interaction.reply({ content: "User is not in the guild", ephemeral: true });
+      return errorSoft(interaction, "User is not in the guild")
     }
 
     // makes sure the user has the ban permission
     if (!moderator.permissions.has(PermissionsBitField.Flags.BanMembers)) {
-      return interaction.reply({
-        content: "You do not have permission to ban members!",
-        ephemeral: true,
-      });
+      return errorSoft(interaction, "You do not have permission to ban members!")
     }
 
     // makes sure the user is not the bot
     if (member.user.bot) {
-      return interaction.reply({ content: "You cannot ban a bot!", ephemeral: true });
+      return errorSoft(interaction, 'You cannot ban a bot!')
     }
 
     // makes sure the user is not admin
     if (member === moderator) {
-      return interaction.reply({ content: "You cannot ban yourself!", ephemeral: true });
+      return errorSoft(interaction, "You cannot ban yourself!")      
     }
 
     if (!member.bannable) {
-      return interaction.reply({ content: `I cannot ban this user`, ephemeral: true });
+      return errorSoft(interaction, "I cannot ban this user")
     }
 
     member.ban({ reason: `${moderator} - ${reason || "No reason provided"}` });

--- a/src/interactions/commands/clear.js
+++ b/src/interactions/commands/clear.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder, PermissionsBitField } = require("discord.js");
-
+const { errorSoft, success } = require('../embeds')
 module.exports = {
   helpinfo: "This comand is used to clear a channel of messages (up to 100)",
   data: new SlashCommandBuilder()
@@ -20,13 +20,11 @@ module.exports = {
     const amount = interaction.options.getInteger("number");
     const channel = interaction.channel;
     if (!admin.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
-      return interaction.reply({
-        content: "You do not have permission to clear messages!",
-        ephemeral: true,
-      });
+      return errorSoft(interaction, "You do not have permission to clear messages!");
+
     }
 
     await channel.bulkDelete(amount);
-    interaction.reply({ content: `Cleared ${amount} messages!`, ephemeral: true });
+    success(interaction, `Cleared ${amount} messages!`);
   },
 };

--- a/src/interactions/commands/help.js
+++ b/src/interactions/commands/help.js
@@ -8,7 +8,7 @@ module.exports = {
 
   async execute(interaction) {
     //get the helpinfo from each command file
-    const commands = fs.readdirSync("../src/commands");
+    const commands = fs.readdirSync(__dirname);
     const commandList = [];
     for (const command of commands) {
       const commandData = require(`./${command}`);

--- a/src/interactions/commands/kick.js
+++ b/src/interactions/commands/kick.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder, PermissionsBitField, CommandInteraction } = require("discord.js");
-
+const { errorSoft } = require('../embeds')
 module.exports = {
   helpinfo: "This comand is used to kick a user from the server",
   data: new SlashCommandBuilder()
@@ -24,28 +24,25 @@ module.exports = {
 
     // makes sure the user is in the guild
     if (!member) {
-      return interaction.reply({ content: "User is not in the guild", ephemeral: true });
+      return errorSoft(interaction, "User is not in the guild")
     }
     // makes sure the user has the kick permission
     if (!moderator.permissions.has(PermissionsBitField.Flags.KickMembers)) {
-      return interaction.reply({
-        content: "You do not have permission to kick members!",
-        ephemeral: true,
-      });
+      return errorSoft(interaction, "You do not have permission to kick members!")
     }
 
     // makes sure the user is not the bot
     if (member.user.bot) {
-      return interaction.reply({ content: "You cannot kick a bot!", ephemeral: true });
+      return errorSoft(interaction, "You cannot kick a bot!")
     }
 
     // makes sure the user is not admin
     if (member === moderator) {
-      return interaction.reply({ content: "You cannot kick yourself!", ephemeral: true });
+      return errorSoft(interaction, "You cannot kick yourself!")
     }
 
     if (!member.kickable) {
-      return interaction.reply({ content: `I cannot kick this user`, ephemeral: true });
+      return errorSoft(interaction, "I cannot kick this user")
     }
 
     member.kick({ reason: `${moderator} - ${reason || "No reason provided"}` });

--- a/src/interactions/commands/mute.js
+++ b/src/interactions/commands/mute.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder, PermissionsBitField, CommandInteraction } = require("discord.js");
-
+const { errorSoft, success } = require('../embeds')
 module.exports = {
   helpinfo: "This comand is used to mute/unmute a user",
   data: new SlashCommandBuilder()
@@ -8,7 +8,7 @@ module.exports = {
     .setDescription("mute/unmute a user")
     .addSubcommand((subcommand) =>
       subcommand
-        .setName("mute")
+        .setName("add")
         .setDescription("mute a user")
         .addUserOption((option) =>
           option.setName("user").setDescription("user to mute").setRequired(true)
@@ -16,7 +16,7 @@ module.exports = {
     )
     .addSubcommand((subcommand) =>
       subcommand
-        .setName("unmute")
+        .setName("remove")
         .setDescription("unmute a user")
         .addUserOption((option) =>
           option.setName("user").setDescription("user to unmute").setRequired(true)
@@ -34,50 +34,44 @@ module.exports = {
 
     // Checks before mute or unmute
     if (!member) {
-      return interaction.reply({ content: "User is not in the guild", ephemeral: true });
+      return errorSoft(interaction, "User is not in the guild");
     }
 
     // makes sure the user has the kick permission
     if (!moderator.permissions.has(PermissionsBitField.Flags.MuteMembers)) {
-      return interaction.reply({
-        content: "You do not have permission to mute/unmute members!",
-        ephemeral: true,
-      });
+      return errorSoft(interaction, "You do not have permission to mute/unmute members!");
     }
 
     // makes sure the user is not the bot
     if (member.user.bot) {
-      return interaction.reply({ content: "You cannot mute/unmute a bot!", ephemeral: true });
+      return errorSoft(interaction, "You cannot mute/unmute a bot!");
     }
 
     // makes sure the user is not admin
     if (member === moderator) {
-      return interaction.reply({ content: "You cannot mute/unmute yourself!", ephemeral: true });
+      return errorSoft(interaction, "You cannot mute/unmute yourself!");
     }
 
     if (!member.manageable) {
-      return interaction.reply({ content: `I cannot mute/unmute this user`, ephemeral: true });
+      return errorSoft(interaction, "I cannot mute/unmute this user");
     }
 
     //check if the server has a mute role
     const muteRole = interaction.guild.roles.cache.find((role) => role.name === "Muted");
     if (!muteRole) {
-      return interaction.reply({
-        content: `This server does not have a "Muted" role, plesae create one and rerun this command.`,
-        ephemeral: true,
-      });
+      return errorSoft(interaction, `This server does not have a "Muted" role, plesae create one and rerun this command.`);
       //todo, create the role automatically and create overrides on channels/categpries to make it actually functional
     }
 
     console.log("passed all checks");
 
     // mute/unmute the user
-    if (subcommand === "mute") {
+    if (subcommand === "add") {
       member.roles.add(muteRole.id);
-      interaction.reply({ content: `${member} has been muted`, ephemeral: true });
-    } else if (subcommand === "unmute") {
+      success(interaction, `${member} has been muted`)
+    } else if (subcommand === "remove") {
       member.roles.remove(muteRole);
-      interaction.reply({ content: `${member} has been unmuted`, ephemeral: true });
+      success(interaction, `${member} has been unmuted`)
     }
   },
 };

--- a/src/interactions/commands/mute.js
+++ b/src/interactions/commands/mute.js
@@ -9,7 +9,7 @@ module.exports = {
     .addSubcommand((subcommand) =>
       subcommand
         .setName("add")
-        .setDescription("mute a user")
+        .setDescription("mute a user for 28 days")
         .addUserOption((option) =>
           option.setName("user").setDescription("user to mute").setRequired(true)
         )
@@ -52,26 +52,18 @@ module.exports = {
       return errorSoft(interaction, "You cannot mute/unmute yourself!");
     }
 
-    if (!member.manageable) {
+    if (!member.manageable || !member.moderatable) {
       return errorSoft(interaction, "I cannot mute/unmute this user");
     }
-
-    //check if the server has a mute role
-    const muteRole = interaction.guild.roles.cache.find((role) => role.name === "Muted");
-    if (!muteRole) {
-      return errorSoft(interaction, `This server does not have a "Muted" role, plesae create one and rerun this command.`);
-      //todo, create the role automatically and create overrides on channels/categpries to make it actually functional
-    }
-
     console.log("passed all checks");
 
     // mute/unmute the user
     if (subcommand === "add") {
-      member.roles.add(muteRole.id);
-      success(interaction, `${member} has been muted`)
+      member.timeout(1000 * 60 * 60 * 24 * 28)//28 days
+      success(interaction, "Muted", `${member} has been muted for 28 days!`)
     } else if (subcommand === "remove") {
-      member.roles.remove(muteRole);
-      success(interaction, `${member} has been unmuted`)
+      member.timeout(null)
+      success(interaction, "Unmuted", `${member} has been unmuted!`)
     }
   },
 };

--- a/src/interactions/commands/warn.js
+++ b/src/interactions/commands/warn.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require("@discordjs/builders");
 const { EmbedBuilder, PermissionsBitField, CommandInteraction } = require("discord.js");
 const ShortUniqueId = require("short-unique-id");
 const { addWarning, getWarning, removeWarning } = require("../../data/db");
+const { errorSoft } = require("../embeds");
 const uniqueId = new ShortUniqueId();
 
 module.exports = {
@@ -11,7 +12,7 @@ module.exports = {
     .setDescription("Warn a user or see a list of warnings")
     .addSubcommand((subcommand) =>
       subcommand
-        .setName("warn")
+        .setName("add")
         .setDescription("warn a user")
         .addUserOption((option) =>
           option.setName("user").setDescription("user to mute").setRequired(true)
@@ -55,39 +56,28 @@ module.exports = {
 
     // Checks before mute or unmute
     if (!member) {
-      return interaction.reply({
-        content: "User is not in the guild",
-        ephemeral: true,
-      });
+      return errorSoft(interaction, "User is not in the guild");
     }
 
     // makes sure the user has the kick permission
     if (!moderator.permissions.has(PermissionsBitField.Flags.ModerateMembers)) {
-      return interaction.reply({
-        content: "You do not have permission to mute/unmute members!",
-        ephemeral: true,
-      });
+      return errorSoft(interaction, "You do not have permission to mute/unmute members!");
     }
 
     // makes sure the user is not the bot
     if (member.user.bot) {
-      return interaction.reply({
-        content: "You cannot warn a bot!",
-        ephemeral: true,
-      });
+      return errorSoft(interaction, "You cannot warn a bot!");
     }
 
     // makes sure the user is not admin
     if (member === moderator) {
-      return interaction.reply({
-        content: "You cannot do this to yourself!",
-        ephemeral: true,
-      });
+      return errorSoft(interaction, "You cannot do this to yourself!");
+      
     }
 
     // IMPORTANT THIS IS WHERE THE WARN COMMAND IS HANDLED
     await interaction.deferReply(); //prevents timeout
-    if (subcommand === "warn") {
+    if (subcommand === "add") {
       const reason = interaction.options.getString("reason");
       let ID = uniqueId();
       //adding the warning to db

--- a/src/interactions/embeds.js
+++ b/src/interactions/embeds.js
@@ -1,0 +1,33 @@
+const { EmbedBuilder } = require('@discordjs/builders')
+const { CommandInteraction } = require('discord.js')
+const errorImage = "https://i.imgur.com/McAinWv.png"
+/**
+ * **sends** error embed
+ * @param {CommandInteraction} intearction 
+ */
+module.exports.errorSoft = async (intearction, title, description) => {
+    let embed = new EmbedBuilder()
+        .setColor(0xFFCC4D)
+    if (!intearction) throw ("intearction is a required argument");
+    if (title) embed.setTitle("⚠️ " + title)
+    if (description) embed.setDescription(description)
+
+    if (!intearction.replied) await intearction.reply({ embeds: [embed], ephemeral: true })
+    else await intearction.channel.send({ embeds: [embed], ephemeral: true })
+    return;
+}
+/**
+ * **sends** success embed
+ * @param {CommandInteraction} intearction 
+ */
+module.exports.success = async (intearction, title, description) => {
+    let embed = new EmbedBuilder()
+    .setColor(0x77B255)
+    if (!intearction) throw ("intearction is a required argument");
+    if (title) embed.setTitle("✅ " + title)
+    if (description) embed.setDescription(description)
+
+    if (!intearction.replied) await intearction.reply({ embeds: [embed], ephemeral: true })
+    else await intearction.channel.send({ embeds: [embed], ephemeral: true })
+    return;
+}


### PR DESCRIPTION
1. Created a module to handle message embeds for all success and error messages.
2. Renamed two commands for better semantics.
3. `mongoUser` and `mongoPass` are now just one config var, `mongoUri`.